### PR TITLE
[FE] 다이얼로그 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Dialog/index.styles.ts
+++ b/frontend/src/components/Dialog/index.styles.ts
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+
+export const DialogOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5); /* 배경 어둡게 */
+  display: flex;
+  justify-content: center;
+  align-items: center; /* 수직, 수평 가운데 정렬 */
+  z-index: 999; /* 다이얼로그가 최상단에 나타나도록 */
+`;
+
+export const DialogWrapper = styled.div<{ width: string }>`
+  width: ${({ width }) => width};
+  background-color: white;
+  border-radius: 25px;
+  padding: 2rem;
+  text-align: center;
+  height: 19.2rem;
+  position: relative;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+`;
+
+export const Description = styled.p`
+  font-size: 3rem;
+  text-align: left;
+  margin-bottom: 3rem;
+  padding: 2rem;
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  bottom: 2rem;
+  right: 2rem;
+  gap: 1rem;
+`;
+
+export const CancelButton = styled.button`
+  border: 1px solid black;
+  background-color: white;
+  color: black;
+  font-size: 1.6rem;
+  width: 12.5rem;
+  height: 3.5rem;
+  border-radius: 15px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f2f2f2;
+  }
+`;
+
+export const ConfirmButton = styled.button`
+  border: 1px solid black;
+  background-color: black;
+  color: white;
+  font-size: 1.6rem;
+  width: 12.5rem;
+  height: 3.5rem;
+  border-radius: 15px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #333;
+  }
+`;

--- a/frontend/src/components/Dialog/index.tsx
+++ b/frontend/src/components/Dialog/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import * as S from './index.styles';
+
+interface DialogProps {
+  width: string;
+  description: string;
+  confirmButton?: () => void;
+  confirmTitle?: string;
+  cancelButton: () => void;
+  cancelTitle: string;
+}
+function Dialog({
+  width,
+  description,
+  confirmButton,
+  confirmTitle = '확인',
+  cancelButton,
+  cancelTitle,
+}: DialogProps) {
+  return (
+    <S.DialogOverlay>
+      <S.DialogWrapper width={width}>
+        <S.Description>{description}</S.Description>
+        <S.ButtonGroup>
+          <S.CancelButton onClick={cancelButton}>{cancelTitle}</S.CancelButton>
+          {confirmButton && (
+            <S.ConfirmButton onClick={confirmButton}>
+              {confirmTitle}
+            </S.ConfirmButton>
+          )}
+        </S.ButtonGroup>
+      </S.DialogWrapper>
+    </S.DialogOverlay>
+  );
+}
+
+export default Dialog;

--- a/frontend/src/pages/main/index.styles.ts
+++ b/frontend/src/pages/main/index.styles.ts
@@ -7,7 +7,6 @@ export const Container = styled.div`
   gap: 2rem;
   padding: 6.7rem;
   display: flex;
-  background-color: gray;
   h1 {
     font-size: 4.5rem;
     font-weight: 600;

--- a/frontend/src/pages/main/index.tsx
+++ b/frontend/src/pages/main/index.tsx
@@ -1,13 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as S from './index.styles';
 import useStore from '../../store';
+import Dialog from '../../components/Dialog';
 
 export default function Main() {
   const { activeIndex } = useStore();
   const Tabs = ['All', 'React', 'CS', 'Network'];
-
+  const [isDialogOpen, setIsDialogOpen] = useState(true);
+  const handleConfirm = () => {
+    setIsDialogOpen(false);
+  };
+  const handleCancel = () => {
+    setIsDialogOpen(false);
+  };
   return (
     <S.Container>
+      {isDialogOpen && (
+        <Dialog
+          width="55.6rem"
+          description="로그인 후 이용 가능한 기능이에요."
+          confirmButton={handleConfirm}
+          confirmTitle="로그인"
+          cancelButton={handleCancel}
+          cancelTitle="돌아가기"
+        />
+      )}
       <h1>{Tabs[activeIndex]}</h1>
     </S.Container>
   );


### PR DESCRIPTION
## 📝 Summary
- 로그인한 유저만 이용 가능 다이얼로그
- 삭제 전 안내 다이얼로그
- 수정 후 완료 다이얼로그
- 등록 후 완료 다이얼로그

: 재사용가능한 다이얼로그 컴포넌트 제작하였습니다. 
너비, 확인버튼, 확인버튼 타이틀, 취소버튼, 취소버튼 타이틀, 다이어로그 타이틀을 프롭스로 받아서 다이얼로그 컴포넌트를 가져다 사용합니다.

## 🖼️ Screenshots

<!-- 필요한 경우 스크린샷을 첨부해 주세요 -->
![스크린샷 2024-10-24 오후 5 14 10](https://github.com/user-attachments/assets/f9c20f51-db05-4e3b-b382-f814ef37c167)
![image](https://github.com/user-attachments/assets/565434d1-0c22-4202-805b-e8dd24cf90a7)