### PR TITLE
[BE] feature: 회원가입 유효성 검사 로직 구현

### DIFF
--- a/BackEnd/controllers/userController.js
+++ b/BackEnd/controllers/userController.js
@@ -8,42 +8,62 @@ const validators = {
   validateUsername: username => {
     if (!username) {
       return {
+        status: 400,
         isValid: false,
-        message: 'id는 필수 입력 사항입니다.',
-        field: 'username',
+        errors: {
+          message: 'id는 필수 입력 사항입니다.',
+          field: 'username',
+        },
       };
     }
-    const usernameRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{6,18}$/;
+    const usernameRegex = /^(?=.*[a-z])(?=.*\d)[A-Za-z\d]{6,18}$/;
     if (!usernameRegex.test(username)) {
       return {
+        status: 400,
         isValid: false,
-        message: 'id는 6~18자의 영문 대/소문자, 숫자를 포함해야 합니다.',
-        field: 'username',
+        errors: {
+          message: 'id는 6~18자의 영문 소문자, 숫자를 포함해야 합니다.',
+          field: 'username',
+        },
       };
     }
-    return { isValid: true };
+    return {
+      status: 200,
+      isValid: true,
+      message: 'id의 조건을 모두 만족합니다.',
+    };
   },
 
   // 비밀번호 유효성 검사 객체
   validatePassword: password => {
     if (!password) {
       return {
+        status: 400,
         isValid: false,
-        message: 'password는 필수 입력 사항입니다.',
-        field: 'password',
+        errors: {
+          message: 'password는 필수 입력 사항입니다.',
+          field: 'password',
+        },
       };
     }
     const passwordRegex =
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{10,18}$/;
     if (!passwordRegex.test(password)) {
       return {
+        status: 400,
         isValid: false,
-        message:
-          '비밀번호는 10~18자의 영문 대/소문자, 숫자, 특수문자(!@#$%^&*)를 포함해야 합니다.',
-        field: 'password',
+        errors: {
+          message:
+            '비밀번호는 10~18자의 영문 대/소문자, 숫자, 특수문자(!@#$%^&*)를 포함해야 합니다.',
+          field: 'password',
+        },
       };
     }
-    return { isValid: true };
+    return {
+      status: 200,
+      isValid: true,
+      message: 'password의 조건을 모두 만족합니다.',
+    };
   },
 };
 
@@ -66,8 +86,12 @@ exports.signupUser = async (req, res) => {
     const existingUser = await User.findOne({ username });
     if (existingUser) {
       return res.status(409).json({
-        message: '이미 등록된 회원입니다.',
-        field: 'username',
+        status: 409,
+        success: false,
+        errors: {
+          message: '이미 등록된 회원입니다.',
+          field: 'username',
+        },
       });
     }
 
@@ -80,13 +104,21 @@ exports.signupUser = async (req, res) => {
 
     // 회원가입 성공할 경우 사용자 데이터 반환
     res.status(201).json({
+      status: 201,
+      success: true,
       message: '회원가입이 성공적으로 완료되었습니다.',
-      user: userDoc,
+      data: {
+        user: userDoc,
+      },
     });
   } catch (e) {
     res.status(500).json({
-      message: '서버 에러 발생',
-      error: e,
+      status: 500,
+      success: false,
+      errors: {
+        message: '서버 에러 발생',
+        error: e,
+      },
     });
   }
 };
@@ -104,18 +136,29 @@ exports.idCheckUser = async (req, res) => {
     const existingUser = await User.findOne({ username });
     if (existingUser) {
       return res.status(409).json({
-        message: '사용중인 id입니다.',
-        field: 'username',
+        status: 409,
+        success: false,
+        errors: {
+          message: '사용중인 id입니다.',
+          field: 'username',
+        },
       });
     } else {
       return res.status(200).json({
+        status: 200,
+        success: true,
         message: '사용 가능한 id입니다.',
+        username: username,
       });
     }
   } catch (e) {
     res.status(500).json({
-      message: '서버 에러 발생',
-      error: e.message,
+      status: 500,
+      success: false,
+      errors: {
+        message: '서버 에러 발생',
+        error: e.message,
+      },
     });
   }
 };

--- a/BackEnd/controllers/userController.js
+++ b/BackEnd/controllers/userController.js
@@ -2,22 +2,65 @@ const path = require('path');
 const User = require(path.join(__dirname, '../models/user'));
 const bcryptjs = require('bcryptjs');
 
-// -------------------비밀번호 해시 생성 함수-------------------
-const hashPassword = password => {
-  const saltRounds = 10; // 해시 생성 시 사용되는 salt
-  return bcryptjs.hashSync(password, saltRounds);
+// -------------------유효성 검사 객체---------------------------
+const validators = {
+  // 아이디 유효성 검사 객체
+  validateUsername: username => {
+    if (!username) {
+      return {
+        isValid: false,
+        message: 'id는 필수 입력 사항입니다.',
+        field: 'username',
+      };
+    }
+    const usernameRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{6,18}$/;
+    if (!usernameRegex.test(username)) {
+      return {
+        isValid: false,
+        message: 'id는 6~18자의 영문 대/소문자, 숫자를 포함해야 합니다.',
+        field: 'username',
+      };
+    }
+    return { isValid: true };
+  },
+
+  // 비밀번호 유효성 검사 객체
+  validatePassword: password => {
+    if (!password) {
+      return {
+        isValid: false,
+        message: 'password는 필수 입력 사항입니다.',
+        field: 'password',
+      };
+    }
+    const passwordRegex =
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{10,18}$/;
+    if (!passwordRegex.test(password)) {
+      return {
+        isValid: false,
+        message:
+          '비밀번호는 10~18자의 영문 대/소문자, 숫자, 특수문자(!@#$%^&*)를 포함해야 합니다.',
+        field: 'password',
+      };
+    }
+    return { isValid: true };
+  },
 };
 
 // -------------------회원가입 로직---------------------------
 exports.signupUser = async (req, res) => {
   const { username, password } = req.body;
 
-  // 필수 필드 체크
-  if (!username || !password) {
-    return res
-      .status(400)
-      .json({ message: 'id와 password는 필수 입력 사항 입니다.' });
+  const usernameValidation = validators.validateUsername(username);
+  if (!usernameValidation.isValid) {
+    return res.status(400).json(usernameValidation);
   }
+
+  const passwordValidation = validators.validatePassword(password);
+  if (!passwordValidation.isValid) {
+    return res.status(400).json(passwordValidation);
+  }
+
   try {
     // 등록된 회원인지 확인
     const existingUser = await User.findOne({ username });
@@ -29,9 +72,9 @@ exports.signupUser = async (req, res) => {
     }
 
     // 비밀번호 암호화
-    const hashedPassword = hashPassword(password);
+    const hashedPassword = await bcryptjs.hash(password, 10);
     const userDoc = await User.create({
-      username,
+      username: username.trim(),
       password: hashedPassword,
     });
 
@@ -52,11 +95,9 @@ exports.signupUser = async (req, res) => {
 exports.idCheckUser = async (req, res) => {
   const { username } = req.body;
 
-  if (!username || typeof username !== 'string') {
-    return res.status(400).json({
-      message: 'id는 필수 입력 사항입니다.',
-      field: 'username',
-    });
+  const usernameValidation = validators.validateUsername(username);
+  if (!usernameValidation.isValid) {
+    return res.status(400).json(usernameValidation);
   }
 
   try {


### PR DESCRIPTION
## 📝 Summary
- 비밀번호 암호화 동기적 메서드인 hashSync를 비동기 메서으 hash로 변경 후 signupUser 함수 내에서 await를 붙여 수정했습니다.
- id, password 유효성 검사 (빈값일 때, 팀에서 정한 유효성 검사)를 만족하지 않을 경우를 객체로 분리하여 함수 밖에서 작성하였습니다.
- 유효성 검사 객체를 signupUser, idCheckUser 함수 내에서 isValid의 참/거짓 유무로 상태 코드와 메세지를 반환하였습니다. 

## 🖼️ Screenshots

**회원가입**
![image](https://github.com/user-attachments/assets/76dc676b-5068-4dc0-ae37-318de3606523)
![image](https://github.com/user-attachments/assets/47694d4f-d43f-4e3c-bf3a-f3da91babfd0)
![image](https://github.com/user-attachments/assets/3c767822-f4b7-48a0-b187-25cac575ea5e)
![image](https://github.com/user-attachments/assets/c85e8a13-a364-4734-a281-1c6cd7924927)
![image](https://github.com/user-attachments/assets/93c7b018-de86-44e2-b938-a5e4f68779c9)

username 중복확인 (회원가입)
![image](https://github.com/user-attachments/assets/ab0f304d-8063-489c-b52c-283b434cf9f6)
![image](https://github.com/user-attachments/assets/5b166a06-ea8c-484a-b732-d749296ad2c5)
![image](https://github.com/user-attachments/assets/502b99e9-9edf-4862-ae54-01e710711730)
![image](https://github.com/user-attachments/assets/74fd21b9-f64b-45c2-b646-85215368f1ad)



## ✅ PR Checklist
 사용자가 중복 확인을 누르지 않고 회원가입을 할 경우에 대한 에러 처리는 백엔드에서 중복 확인에 대한 boolean 타입의 변수를 추가해서 처리 해줘야 하는 건지, 프론트에서 처리 해줘야 하는 건지 잘 모르겠습니다.
-> 라고 생각했는데 프론트 단에서 중복 확인 api를 거치지 않으면 회원 가입 자체가 안되게끔 하면 될 것 같습니다.

### 공통

- [x] 하나의 목적을 가진 PR입니다.
- [ ] 코딩 컨벤션을 준수합니다.
- [ ] 불필요한 코드 중복이 없습니다.
- [ ] 민감한 정보를 포함하지 않았습니다.
- [ ] 불필요한 콘솔 로그나 주석을 포함하지 않았습니다.

### 프론트

- [ ] 컴포넌트의 책임이 단일합니다.
- [ ] 리액트 훅을 올바르게 사용했습니다.
- [ ] 컴포넌트 key값에 고유한 값을 할당했습니다.

### 백엔드

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #27

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->
