### PR TITLE
[BE] feature:  login 구현

### DIFF
--- a/BackEnd/app.js
+++ b/BackEnd/app.js
@@ -2,12 +2,11 @@ require('dotenv').config();
 const express = require('express');
 const mongoose = require('mongoose');
 const path = require('path');
-const cors = require('cors');  // CORS 추가
+const cors = require('cors'); // CORS 추가
 const postRoutes = require(path.join(__dirname, './routes/postRoutes'));
 const userRoutes = require(path.join(__dirname, './routes/userRoutes'));
 
 const app = express();
-
 
 // MongoDB 연결
 mongoose
@@ -20,10 +19,9 @@ mongoose
   });
 
 // 미들웨어 설정
-app.use(cors());  // CORS 미들웨어 추가
+app.use(cors()); // CORS 미들웨어 추가
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-
 
 // 라우트 설정
 app.use('/posts', postRoutes);

--- a/BackEnd/controllers/userController.js
+++ b/BackEnd/controllers/userController.js
@@ -224,7 +224,7 @@ exports.loginUser = async (req, res) => {
       .cookie('token', token, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production', // 프로덕션 환경에서만 HTTPS 설정
-        ameSite: process.env.NODE_ENV === 'production' ? 'strict' : 'lax', // https에서만 secure: true, 로컬 환경 http에서는 none 설정
+        sameSite: process.env.NODE_ENV === 'production' ? 'strict' : 'lax', // https에서만 secure: true, 로컬 환경 http에서는 none 설정
         maxAge: COOKIE_EXPIRE_TIME,
       })
       .json({

--- a/BackEnd/controllers/userController.js
+++ b/BackEnd/controllers/userController.js
@@ -1,8 +1,14 @@
 const path = require('path');
 const User = require(path.join(__dirname, '../models/user'));
 const bcryptjs = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { env } = require('process');
 
-// -------------------유효성 검사 객체---------------------------
+const secretKey = process.env.SECRET_KEY;
+const TOKEN_EXPIRE_TIME = '24h'; // 토큰 만료 시간 (임시)
+const COOKIE_EXPIRE_TIME = 24 * 60 * 60 * 1000; // 24시간 (임시)
+
+// -------------------유효성 검사 객체------------------------
 const validators = {
   // 아이디 유효성 검사 객체
   validateUsername: username => {
@@ -123,7 +129,7 @@ exports.signupUser = async (req, res) => {
   }
 };
 
-// -------------------username 중복확인 로직-------------------
+// -------------------username 중복확인 로직------------------
 exports.idCheckUser = async (req, res) => {
   const { username } = req.body;
 
@@ -163,5 +169,82 @@ exports.idCheckUser = async (req, res) => {
   }
 };
 
-// -------------------로그인 로직-------------------
-// TODO
+// -------------------로그인 로직-----------------------------
+exports.loginUser = async (req, res) => {
+  // username, password 입력 받기
+  const { username, password } = req.body;
+
+  try {
+    // db에 user 정보 찾기
+    const userDoc = await User.findOne({ username });
+
+    // username이 잘못된 경우
+    if (!userDoc) {
+      return res.status(404).json({
+        status: 404,
+        success: false,
+        errors: {
+          message: '존재하지 않는 사용자입니다',
+          field: 'username',
+        },
+      });
+    }
+
+    // 비밀번호 검증
+    const isPasswordCorrect = await bcryptjs.compare(
+      password,
+      userDoc.password,
+    );
+
+    // 비밀번호가 db에 있는 password와 일치하지 않는 경우
+    if (!isPasswordCorrect) {
+      res.status(401).json({
+        status: 401,
+        success: false,
+        errors: {
+          message: '비밀번호가 일치하지 않습니다.',
+          field: 'password',
+        },
+      });
+    }
+
+    // JWT 페이로드에 유저 정보 포함
+    const payload = {
+      id: userDoc._id,
+      username,
+    };
+
+    // 로그인 성공 시 유저 정보로 토큰 생성
+    const token = jwt.sign(payload, secretKey, {
+      expiresIn: TOKEN_EXPIRE_TIME,
+    });
+
+    // Set-cookie 헤더로 jwt 토큰 설정
+    res
+      .cookie('token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production', // 프로덕션 환경에서만 HTTPS 설정
+        ameSite: process.env.NODE_ENV === 'production' ? 'strict' : 'lax', // https에서만 secure: true, 로컬 환경 http에서는 none 설정
+        maxAge: COOKIE_EXPIRE_TIME,
+      })
+      .json({
+        status: 200,
+        success: true,
+        message: '로그인 성공. 토큰이 발급되었습니다.',
+        data: {
+          id: userDoc._id,
+          username,
+          token: token,
+        },
+      });
+  } catch (e) {
+    res.status(500).json({
+      status: 500,
+      success: false,
+      errors: {
+        message: '서버 에러 발생',
+        error: e,
+      },
+    });
+  }
+};

--- a/BackEnd/middleware/auth.js
+++ b/BackEnd/middleware/auth.js
@@ -1,23 +1,70 @@
+// // middleware/auth.js
+// const verifyToken = (req, res, next) => {
+//     // 헤더에서 토큰 가져오기
+//     const token = req.header('Authorization');
+//     // 토큰이 없는 경우
+//     if (!token) {
+//         return res.status(401).json({ message: '인증 토큰이 필요합니다.' });
+//     }
+//     try {
+//         // 테스트용이므로 토큰이 존재하기만 하면 통과
+//         // 실제 환경에서는 JWT 등을 사용하여 토큰 검증 필요
+//         if (token.startsWith('Bearer ')) {
+//             // Bearer 토큰에서 실제 토큰 값만 추출
+//             req.token = token.slice(7);
+//             next();
+//         } else {
+//             throw new Error('잘못된 토큰 형식입니다.');
+//         }
+//     } catch (err) {
+//         res.status(401).json({ message: '유효하지 않은 토큰입니다.' });
+//     }
+// };
+// module.exports = verifyToken;
+
 // middleware/auth.js
+
+// 추가
+
+// middleware/auth.js
+const jwt = require('jsonwebtoken');
+const secretKey = process.env.SECRET_KEY;
+
 const verifyToken = (req, res, next) => {
-    // 헤더에서 토큰 가져오기
-    const token = req.header('Authorization');
-    // 토큰이 없는 경우
+  try {
+    // 헤더 또는 쿠키에서 토큰 확인
+    const token =
+      req.cookies.token || req.header('Authorization')?.replace('Bearer ', '');
+
     if (!token) {
-        return res.status(401).json({ message: '인증 토큰이 필요합니다.' });
+      return res.status(401).json({
+        success: false,
+        message: '인증 토큰이 필요합니다.',
+      });
     }
-    try {
-        // 테스트용이므로 토큰이 존재하기만 하면 통과
-        // 실제 환경에서는 JWT 등을 사용하여 토큰 검증 필요
-        if (token.startsWith('Bearer ')) {
-            // Bearer 토큰에서 실제 토큰 값만 추출
-            req.token = token.slice(7);
-            next();
-        } else {
-            throw new Error('잘못된 토큰 형식입니다.');
-        }
-    } catch (err) {
-        res.status(401).json({ message: '유효하지 않은 토큰입니다.' });
+
+    // JWT 토큰 검증
+    const decoded = jwt.verify(token, secretKey);
+
+    // 검증된 사용자 정보를 request 객체에 저장
+    req.user = decoded;
+    next();
+  } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      return res.status(401).json({
+        success: false,
+        message: '토큰이 만료되었습니다.',
+      });
     }
+
+    res.status(401).json({
+      success: false,
+      message: '유효하지 않은 토큰입니다.',
+    });
+  }
 };
+
 module.exports = verifyToken;
+const { json } = require('body-parser');
+const { verify } = require('jsonwebtoken');
+const { cookies } = require('next/headers');

--- a/BackEnd/routes/userRoutes.js
+++ b/BackEnd/routes/userRoutes.js
@@ -12,6 +12,6 @@ router.post('/signup', userController.signupUser);
 router.post('/idCheck', userController.idCheckUser);
 
 // user login
-// router.post('/user/login', userController.loginUser);
+router.post('/login', userController.loginUser);
 
 module.exports = router;


### PR DESCRIPTION
## 📝 Summary
- 상태코드
    - db에 등록된 사용자가 아닌 경우: 404
    - db에 있는 사용자 비밀번호와 입력 비밀번호가 다른 경우: 401
    - 로그인 성공한 경우: 200
-  토큰 생성
    - 로그인에 성공할 경우 jwt로 토큰 생성
    -> payload에 objectId, username 넣어줌
    - 생성된 토큰을 set-Cookie(res.cookie를 의미)로 헤더에 넣어 전송해줌
    - httpOnly: true로 설정해 브라우저에서 자바스크립트로 토큰 수정 방지 -> XSS 공격 보호
    - secure: process.env.NODE_ENV === 'production')로 설정해 프로덕션 환경에서만 secure: true로 설정하여 네트워크에서 공격자가 가로채는 것을 방지. 로컬에서는 https 없이도 테스트 가능하도록 설정
    - sameSite를 프로덕션 환경에서만 true로 설정해 CSRF 공격을 완화 (쿠키는 Bearder 토큰을 사용하지 않기 때문에 CSRF에 취약하다고 함)

## 🖼️ Screenshots
![image](https://github.com/user-attachments/assets/d8232738-4099-4de9-bcf6-bdbe233ee4c1)
![image](https://github.com/user-attachments/assets/12b05b78-76e5-4082-bf5c-0cfbebaf9a74)
![image](https://github.com/user-attachments/assets/11857de8-38b0-45b9-8723-0d04f7fe6bc3)


## ✅ PR Checklist
쿠키에 저장하는 거랑 헤더에 Bearer 토큰으로 저장하는 거랑 계속 헷갈려서 찾아봤는데 발급한 jwt 토큰을 쿠키에 저장(res.cookie) 하면 set-Cookie 방식으로 자동으로 헤더에 넘어간다고 해요. 이런 방식으로 프론트에게 토큰을 주게 되면 프론트에서는 로그인 요청을 할 때 자동으로 브라우저에 쿠키가 저장돼서 따로 헤더에 처리할 일이 없다고 하네요. jwt 토큰을 Bearer 토큰으로 헤더에 저장하게 되면 프론트에서 헤더에 Authorization Bearer ~로 따로 설정해줘야 하는 것 같아요! (확실친 않지만..) 
그래서 쿠키는 웹뷰에 최적화 되어 있고 Bearer 방식은 웹, 모바일 등등 다 사용할 수 있는 것 같아요. 
혹시 제가 잘못 알고 있다면 말씀해주세요..!

저는 일단 쿠키로 하기로 했으니까 쿠키로 구현은 해놓은 상황인데 주영님꼐서 미들웨어 부분에 Bearer 방식 사용하신 것 같아서 쿠키 인증 방식 로직 추가 해놔서 보시고 조율하면 될 것 같습니다!   

쿠키랑 Bearer 차이 링크 공유드릴게요!
- https://velog.io/@jeris/Response-%ED%94%84%EB%A1%9C%EB%AF%B8%EC%8A%A4-%EA%B0%9D%EC%B2%B4%EC%97%90-Set-Cookie-%ED%97%A4%EB%8D%94%EA%B0%80-%ED%8F%AC%ED%95%A8%EB%90%98%EC%96%B4-%EC%A0%84%EB%8B%AC%EB%90%A0-%EA%B2%BD%EC%9A%B0-%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80%EC%97%90%EC%84%9C-%EC%96%B4%EB%96%A4-%EC%9D%BC%EC%9D%B4-%EB%B0%9C%EC%83%9D%ED%95%98%EB%82%98%EC%9A%94
- https://www.notion.so/3-1251c6afab8c80ecb83be6471eb5188d?p=12d011daa17b800cb94aee4d0fdeef71&pm=s
- https://skay138.github.io/article/cookie-session-jwt/

### 공통

- [ ] 하나의 목적을 가진 PR입니다.
- [ ] 코딩 컨벤션을 준수합니다.
- [ ] 불필요한 코드 중복이 없습니다.
- [ ] 민감한 정보를 포함하지 않았습니다.
- [ ] 불필요한 콘솔 로그나 주석을 포함하지 않았습니다.

### 프론트

- [ ] 컴포넌트의 책임이 단일합니다.
- [ ] 리액트 훅을 올바르게 사용했습니다.
- [ ] 컴포넌트 key값에 고유한 값을 할당했습니다.

### 백엔드

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #20

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->
