### PR TITLE
[FE] - fix: 사이드바 고정, 글쓰기 버튼 z-index 수정

### DIFF
--- a/frontend/src/components/Layout/MainLayout.tsx
+++ b/frontend/src/components/Layout/MainLayout.tsx
@@ -22,8 +22,6 @@ const Inner = styled.div`
 
 const Container = styled.div`
   flex-grow: 1;
-  display: flex;
-  justify-content: end;
   margin-left: 30rem;
 `;
 export default function MainLayout() {

--- a/frontend/src/components/Layout/MainLayout.tsx
+++ b/frontend/src/components/Layout/MainLayout.tsx
@@ -22,7 +22,9 @@ const Inner = styled.div`
 
 const Container = styled.div`
   flex-grow: 1;
-  justify-content: center;
+  display: flex;
+  justify-content: end;
+  margin-left: 30rem;
 `;
 export default function MainLayout() {
   return (

--- a/frontend/src/components/Layout/Sidebar/index.styles.ts
+++ b/frontend/src/components/Layout/Sidebar/index.styles.ts
@@ -14,7 +14,12 @@ export const Container = styled.div`
     font-style: italic;
     padding-bottom: 3rem;
   }
-  position: relative;
+  position: fixed;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  z-index: 900;
+  background-color: white;
 `;
 export const MenuBar = styled.div`
   padding: 0 2rem;

--- a/frontend/src/pages/main/index.styles.ts
+++ b/frontend/src/pages/main/index.styles.ts
@@ -30,6 +30,7 @@ export const PlusButton = styled.button`
   font-weight: normal;
   color: black;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.3);
+  z-index: 999;
 `;
 
 export const MainPage = styled.div`


### PR DESCRIPTION
## 📝 Summary

- [ ] 글쓰기 버튼에 z-index: 999 적용
- [ ] Sidebar의 Container에 position: relative -> position fixed; top: 0; left: 0; height: 100vh; 적용
- [ ] MainLayout.tsx의 Container에 margin-left: 30rem(fixed 속성으로 부유된 사이드바 너비만큼 margin 부여)

## 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/5f0dbb7b-9406-4290-9cde-0dadbfc4b44a)
![image](https://github.com/user-attachments/assets/b66f45f3-fd0b-49bd-875d-60bcb50eca1d)

## ✅ PR Checklist

<!-- 코드 리뷰 시 확인해야 할 사항들 -->

### 공통

- [ ] 하나의 목적을 가진 PR입니다.
- [ ] 코딩 컨벤션을 준수합니다.
- [ ] 불필요한 코드 중복이 없습니다.
- [ ] 민감한 정보를 포함하지 않았습니다.
- [ ] 불필요한 콘솔 로그나 주석을 포함하지 않았습니다.

### 프론트

- [ ] 컴포넌트의 책임이 단일합니다.
- [ ] 리액트 훅을 올바르게 사용했습니다.
- [ ] 컴포넌트 key값에 고유한 값을 할당했습니다.

### 백엔드

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #95

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->
